### PR TITLE
Do not add the handler when loading the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 0.3.1
+
+- Do not add a default log handler.
+
 ## 0.3.0
 
 - Add support for python 3.7 and 3.8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## 0.3.1
+## 0.4.0
 
 - Do not add a default log handler.
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -38,6 +38,10 @@ function runOneLinerNotExpected {
     if [ $? == 0 ] ; then
         exit 1
     fi
+    if ! grep -F ":root:" $stderr > /dev/null ; then
+        echo "Output of root logger not found"
+        exit 1
+    fi
 }
 
 function runOneLinerExpected {
@@ -54,6 +58,10 @@ function runOneLinerExpected {
     if [ "${GITHUB_ACTIONS}" != "" ] ; then echo "stop$$" ; fi
     grep -F "$expected" $stderr > /dev/null
     if [ $? != 0 ] ; then
+        exit 1
+    fi
+    if ! grep -F ":root:" $stderr > /dev/null ; then
+        echo "Output of root logger not found"
         exit 1
     fi
 }


### PR DESCRIPTION
Some parts of the logging check if there are already handlers added and adding them by default changes the behavior of the code. Instead of wrapping all the possible functions for configuring the logger the handlers are injected temporary by wrapping the calling of the handlers.